### PR TITLE
Prevent crash when exporting empty movie list

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,6 +101,10 @@ function saveProcessedData(data) {
  * @returns {string}
  */
 function toCSV(data) {
+    if (data.length === 0) {
+        return '';
+    }
+
     const headers = Object.keys(data[0]).join(',');
     const rows = data.map((item) => Object.values(item).map(value => `"${value}"`).join(','));
 


### PR DESCRIPTION
## Summary
- Avoid TypeError in `toCSV` when exporting an empty dataset

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('app.js','utf8');
const sandbox={document:{getElementById:()=>({addEventListener:()=>{}})}};
vm.createContext(sandbox);
vm.runInContext(code, sandbox);
console.log('typeof toCSV in sandbox', typeof sandbox.toCSV);
console.log('toCSV non-empty', sandbox.toCSV([{Title:'Test',Year:2020,Rating10:8,WatchedDate:'2020-01-01',Review:''}]));
console.log('toCSV empty', sandbox.toCSV([]));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a654d0e2ec8323b3f3363e7ff45fa2