### PR TITLE
Escape embedded quotes in CSV export

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,15 @@ function saveProcessedData(data) {
  */
 function toCSV(data) {
     const headers = Object.keys(data[0]).join(',');
-    const rows = data.map((item) => Object.values(item).map(value => `"${value}"`).join(','));
+    const rows = data.map((item) =>
+        Object.values(item)
+            .map((value) => {
+                const stringValue = String(value);
+                const escaped = stringValue.replace(/"/g, '""');
+                return /[",\n]/.test(stringValue) ? `"${escaped}"` : escaped;
+            })
+            .join(',')
+    );
 
     return [headers, ...rows].join('\n');
 }


### PR DESCRIPTION
## Summary
- Escape internal quotes in CSV fields and quote only when needed

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65581b8d48323ba9854b9869f5760