### PR TITLE
Use singular wording in result messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,10 +19,10 @@ document.getElementById('processFiles').addEventListener('click', async () => {
 
         saveProcessedData(processedData);
 
-        resultMessage.innerHTML = `<p style='color: green;'>Files have been successfully processed and saved!</p>`;
+        resultMessage.innerHTML = `<p style='color: green;'>File has been successfully processed and saved!</p>`;
     } catch (error) {
         console.error(error);
-        resultMessage.innerHTML = `<p style='color: red;'>An error occurred while processing files.</p>`;
+        resultMessage.innerHTML = `<p style='color: red;'>An error occurred while processing the file.</p>`;
     }
 });
 


### PR DESCRIPTION
## Summary
- Clarify success message to note a single processed file
- Adjust error message to reference processing the file

## Testing
- `npm test` (fails: ENOENT, could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a655964ae08323b7fc56335e5c8fac